### PR TITLE
--spatial-index option

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ If you have [SpatiaLite](https://www.gaia-gis.it/fossil/libspatialite/index) ava
 
 The data will be loaded into a table called `features` - based on the name of the shapefile. You can specify an alternative table name using `--table`:
 
-    $ shapefile-to-sqlite my.db features.shp --table=places
+    $ shapefile-to-sqlite my.db features.shp --table=places --spatialite
 
 The tool will search for the SpatiaLite module in the following locations:
 
@@ -39,6 +39,12 @@ If you have installed the module in another location, you can use the `--spatial
 
     $ shapefile-to-sqlite my.db features.shp \
         --spatialite_mod=/usr/lib/mod_spatialite.dylib
+
+You can use the `--spatial-index` option to create a spatial index on the `geometry` column:
+
+    $ shapefile-to-sqlite my.db features.shp --spatial-index
+
+You can omit `--spatialite` if you use either `--spatialite-mod` or `--spatial-index`.
 
 ## Projections
 

--- a/shapefile_to_sqlite/cli.py
+++ b/shapefile_to_sqlite/cli.py
@@ -49,6 +49,7 @@ def validate_crs(ctx, param, value):
 )
 @click.option("--alter", is_flag=True, help="Add any missing columns")
 @click.option("--spatialite", is_flag=True, help="Use SpatiaLite")
+@click.option("--spatial-index", is_flag=True, help="Create spatial indexes")
 @click.option(
     "--spatialite_mod",
     help="Path to SpatiaLite module, for if --spatialite cannot find it automatically",
@@ -59,7 +60,17 @@ def validate_crs(ctx, param, value):
     help="Show extra information, including the CRS details",
     is_flag=True,
 )
-def cli(db_path, shapefile, table, crs, alter, spatialite, spatialite_mod, verbose):
+def cli(
+    db_path,
+    shapefile,
+    table,
+    crs,
+    alter,
+    spatialite,
+    spatial_index,
+    spatialite_mod,
+    verbose,
+):
     "Load shapefiles into a SQLite (optionally SpatiaLite) database"
     if verbose and crs:
         print("Output CRS: {}".format(crs))
@@ -93,6 +104,7 @@ def cli(db_path, shapefile, table, crs, alter, spatialite, spatialite_mod, verbo
                     alter=alter,
                     spatialite=spatialite,
                     spatialite_mod=spatialite_mod,
+                    spatial_index=spatial_index,
                 )
                 num_added = db_table.count
                 if verbose:

--- a/shapefile_to_sqlite/utils.py
+++ b/shapefile_to_sqlite/utils.py
@@ -36,6 +36,7 @@ def import_features(
     alter=False,
     spatialite=False,
     spatialite_mod=None,
+    spatial_index=False,
 ):
     db = sqlite_utils.Database(db_path)
     # We need to convert from shapefile_crs to target_crs
@@ -79,7 +80,7 @@ def import_features(
     features_iter = yield_features()
 
     conversions = {}
-    if spatialite_mod:
+    if spatialite_mod or spatial_index:
         spatialite = True
     if spatialite:
         lib = spatialite_mod or find_spatialite()
@@ -99,6 +100,10 @@ def import_features(
     db[table].insert_all(
         features_iter, conversions=conversions, alter=alter, pk="id", replace=True
     )
+
+    if spatial_index:
+        db.conn.execute("select CreateSpatialIndex(?, ?)", [table, "geometry"])
+
     return db[table]
 
 

--- a/tests/test_shapefile_to_sqlite.py
+++ b/tests/test_shapefile_to_sqlite.py
@@ -147,3 +147,17 @@ def test_import_features_spatialite_with_custom_crs(tmpdir):
     ]
     assert ["id"] == db["features"].pks
     assert expected_rows == rows
+
+
+@pytest.mark.skipif(not utils.find_spatialite(), reason="Could not find SpatiaLite")
+def test_import_features_spatial_index(tmpdir):
+    db_path = str(tmpdir / "output.db")
+    result = CliRunner().invoke(
+        cli.cli,
+        [db_path, str(testdir / "features.shp"), "--spatialite", "--spatial-index"],
+        catch_exceptions=False,
+    )
+    assert 0 == result.exit_code, result.stdout
+    db = sqlite_utils.Database(db_path)
+    utils.init_spatialite(db, utils.find_spatialite())
+    assert "idx_features_geometry" in db.table_names()


### PR DESCRIPTION
I'm not convinced this works. I tried it on macOS and got this:

```
Traceback (most recent call last):
  File "/Users/simon/.local/share/virtualenvs/shapefile-to-sqlite-momIhBan/bin/sqlite-utils", line 8, in <module>
    sys.exit(cli())
  File "/Users/simon/.local/share/virtualenvs/shapefile-to-sqlite-momIhBan/lib/python3.8/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/Users/simon/.local/share/virtualenvs/shapefile-to-sqlite-momIhBan/lib/python3.8/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/Users/simon/.local/share/virtualenvs/shapefile-to-sqlite-momIhBan/lib/python3.8/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/simon/.local/share/virtualenvs/shapefile-to-sqlite-momIhBan/lib/python3.8/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/simon/.local/share/virtualenvs/shapefile-to-sqlite-momIhBan/lib/python3.8/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/Users/simon/.local/share/virtualenvs/shapefile-to-sqlite-momIhBan/lib/python3.8/site-packages/sqlite_utils/cli.py", line 744, in query
    db.conn.load_extension(ext)
sqlite3.OperationalError: dlopen(SPATIALITE.dylib, 10): image not found
```