### PR TITLE
setup.py: require pyproj==3.3.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
         [console_scripts]
         shapefile-to-sqlite=shapefile_to_sqlite.cli:cli
     """,
-    install_requires=["sqlite-utils>=2.2", "Shapely", "Fiona", "pyproj"],
+    install_requires=["sqlite-utils>=2.2", "Shapely", "Fiona", "pyproj==3.3.1"],
     extras_require={"test": ["pytest"]},
     tests_require=["shapefile-to-sqlite[test]"],
 )


### PR DESCRIPTION
3.4.0 removed the Transformer.from_crs skip_equivalent arg.